### PR TITLE
Add new arguments (enhancements especially when used in scripted environments)

### DIFF
--- a/attach.c
+++ b/attach.c
@@ -89,9 +89,9 @@ die(int sig)
 {
 	/* Print a nice pretty message for some things. */
 	if (sig == SIGHUP || sig == SIGINT)
-		printf(EOS "\r\n[detached]\r\n");
+		printf("%s[detached]\r\n", clear_csi_data());
 	else
-		printf(EOS "\r\n[got signal %d - dying]\r\n", sig);
+		printf("%s[got signal %d - dying]\r\n", clear_csi_data(), sig);
 	exit(1);
 }
 
@@ -116,7 +116,7 @@ process_kbd(int s, struct packet *pkt)
 
 		/* And suspend... */
 		tcsetattr(0, TCSADRAIN, &orig_term);
-		printf(EOS "\r\n");
+		printf("%s", clear_csi_data());
 		kill(getpid(), SIGTSTP);
 		tcsetattr(0, TCSADRAIN, &cur_term);
 
@@ -134,7 +134,7 @@ process_kbd(int s, struct packet *pkt)
 	/* Detach char? */
 	else if (pkt->u.buf[0] == detach_char)
 	{
-		printf(EOS "\r\n[detached]\r\n");
+		printf("%s[detached]\r\n", clear_csi_data());
 		exit(0);
 	}
 	/* Just in case something pukes out. */
@@ -239,7 +239,7 @@ attach_main(int noerror)
 		n = select(s + 1, &readfds, NULL, NULL, NULL);
 		if (n < 0 && errno != EINTR && errno != EAGAIN)
 		{
-			printf(EOS "\r\n[select failed]\r\n");
+			printf("%s[select failed]\r\n", clear_csi_data());
 			exit(1);
 		}
 
@@ -250,13 +250,12 @@ attach_main(int noerror)
 
 			if (len == 0)
 			{
-				printf(EOS "\r\n[EOF - dtach terminating]"
-					"\r\n");
+				printf("%s[EOF - dtach terminating]\r\n", clear_csi_data());
 				exit(0);
 			}
 			else if (len < 0)
 			{
-				printf(EOS "\r\n[read returned an error]\r\n");
+				printf("%s[read returned an error]\r\n", clear_csi_data());
 				exit(1);
 			}
 			/* Send the data to the terminal. */

--- a/attach.c
+++ b/attach.c
@@ -39,9 +39,10 @@ static void
 restore_term(void)
 {
 	tcsetattr(0, TCSADRAIN, &orig_term);
-
-	/* Make cursor visible. Assumes VT100. */
-	printf("\033[?25h");
+	
+	/* Reset terminal and make cursor visible. Assumes VT100. */
+	printf("\033[0m\033[?25h");
+	
 	fflush(stdout);
 }
 

--- a/attach.c
+++ b/attach.c
@@ -217,7 +217,11 @@ attach_main(int noerror)
 
 	/* Clear the screen. This assumes VT100. */
 	if (clear_method == CLEAR_NONE)
-		write(1, "\r\n", 2);
+		if (!quiet)
+			write(1, "\r\n", 2);
+		else {
+			// NOTE:  Nothing to do in this case!
+		}
 	else
 		write(1, "\033c", 2);
 
@@ -254,7 +258,8 @@ attach_main(int noerror)
 
 			if (len == 0)
 			{
-				printf("%s[EOF - dtach terminating]\r\n", clear_csi_data());
+				if (!quiet)
+					printf("%s[EOF - dtach terminating]\r\n", clear_csi_data());
 				exit(0);
 			}
 			else if (len < 0)

--- a/attach.c
+++ b/attach.c
@@ -216,7 +216,10 @@ attach_main(int noerror)
 	tcsetattr(0, TCSADRAIN, &cur_term);
 
 	/* Clear the screen. This assumes VT100. */
-	write(1, "\33[H\33[J", 6);
+	if (clear_method == CLEAR_NONE)
+		write(1, "\r\n", 2);
+	else
+		write(1, "\033c", 2);
 
 	/* Tell the master that we want to attach. */
 	memset(&pkt, 0, sizeof(struct packet));

--- a/dtach.h
+++ b/dtach.h
@@ -124,12 +124,11 @@ struct packet
 */
 #define BUFSIZE 4096
 
-/* This hopefully moves to the bottom of the screen */
-#define EOS "\033[999H"
-
 int attach_main(int noerror);
 int master_main(char **argv, int waitattach, int dontfork);
 int push_main(void);
+
+char const * clear_csi_data();
 
 #ifdef sun
 #define BROKEN_MASTER

--- a/dtach.h
+++ b/dtach.h
@@ -82,7 +82,7 @@
 #endif
 
 extern char *progname, *sockname;
-extern int detach_char, no_suspend, redraw_method, clear_method;
+extern int detach_char, no_suspend, redraw_method, clear_method, quiet;
 extern struct termios orig_term;
 extern int dont_have_tty;
 

--- a/dtach.h
+++ b/dtach.h
@@ -82,7 +82,7 @@
 #endif
 
 extern char *progname, *sockname;
-extern int detach_char, no_suspend, redraw_method;
+extern int detach_char, no_suspend, redraw_method, clear_method;
 extern struct termios orig_term;
 extern int dont_have_tty;
 
@@ -101,6 +101,13 @@ enum
 	REDRAW_NONE	= 1,
 	REDRAW_CTRL_L	= 2,
 	REDRAW_WINCH	= 3,
+};
+
+enum
+{
+	CLEAR_UNSPEC	= 0,
+	CLEAR_NONE	= 1,
+	CLEAR_MOVE	= 2,
 };
 
 /* The client to master protocol. */

--- a/main.c
+++ b/main.c
@@ -39,6 +39,7 @@ int no_suspend;
 int redraw_method = REDRAW_UNSPEC;
 /* The default clear method. Initially set to unspecified. */
 int clear_method = CLEAR_UNSPEC;
+int quiet = 0;
 
 /*
 ** The original terminal settings. Shared between the master and attach
@@ -85,6 +86,7 @@ usage()
 		"\t\t     none: Don't clear at all.\n"
 		"\t\t     move: Move to last line (default behaviour).\n"
 		"  -z\t\tDisable processing of the suspend key.\n"
+		"  -q\t\tDisable printing of additional messages.\n"
 		"\nReport any bugs to <" PACKAGE_BUGREPORT ">.\n",
 		PACKAGE_VERSION, __DATE__, __TIME__);
 	exit(0);
@@ -165,6 +167,8 @@ main(int argc, char **argv)
 				detach_char = -1;
 			else if (*p == 'z')
 				no_suspend = 1;
+			else if (*p == 'q')
+				quiet = 1;
 			else if (*p == 'e')
 			{
 				++argv; --argc;

--- a/main.c
+++ b/main.c
@@ -161,6 +161,11 @@ main(int argc, char **argv)
 	{
 		char *p;
 
+		if (strcmp(argv[0], "--") == 0) {
+			++argv; --argc;
+			break;
+		}
+
 		for (p = argv[0] + 1; *p; ++p)
 		{
 			if (*p == 'E')

--- a/main.c
+++ b/main.c
@@ -282,3 +282,18 @@ main(int argc, char **argv)
 	}
 	return 0;
 }
+
+
+char const * clear_csi_data()
+{
+	switch (clear_method) {
+		case CLEAR_NONE :
+			return "\r\n";
+		case CLEAR_UNSPEC :
+		case CLEAR_MOVE :
+		default :
+			/* This hopefully moves to the bottom of the screen */
+			return "\033[999H\r\n";
+	}
+}
+

--- a/main.c
+++ b/main.c
@@ -37,6 +37,8 @@ int detach_char = '\\' - 64;
 int no_suspend;
 /* The default redraw method. Initially set to unspecified. */
 int redraw_method = REDRAW_UNSPEC;
+/* The default clear method. Initially set to unspecified. */
+int clear_method = CLEAR_UNSPEC;
 
 /*
 ** The original terminal settings. Shared between the master and attach
@@ -78,6 +80,10 @@ usage()
 		"\t\t     none: Don't redraw at all.\n"
 		"\t\t   ctrl_l: Send a Ctrl L character to the program.\n"
 		"\t\t    winch: Send a WINCH signal to the program.\n"
+		"  -R <method>\tSet the clear method to <method>. The "
+		"valid methods are:\n"
+		"\t\t     none: Don't clear at all.\n"
+		"\t\t     move: Move to last line (default behaviour).\n"
 		"  -z\t\tDisable processing of the suspend key.\n"
 		"\nReport any bugs to <" PACKAGE_BUGREPORT ">.\n",
 		PACKAGE_VERSION, __DATE__, __TIME__);
@@ -202,6 +208,31 @@ main(int argc, char **argv)
 				{
 					printf("%s: Invalid redraw method "
 						"specified.\n", progname);	
+					printf("Try '%s --help' for more "
+						"information.\n", progname);
+					return 1;
+				}
+				break;
+			}
+			else if (*p == 'R')
+			{
+				++argv; --argc;
+				if (argc < 1)
+				{
+					printf("%s: No clear method "
+						"specified.\n", progname);	
+					printf("Try '%s --help' for more "
+						"information.\n", progname);
+					return 1;
+				}
+				if (strcmp(argv[0], "none") == 0)
+					clear_method = CLEAR_NONE;
+				else if (strcmp(argv[0], "move") == 0)
+					clear_method = CLEAR_MOVE;
+				else
+				{
+					printf("%s: Invalid clear method "
+						"specified.\n", progname);
 					printf("Try '%s --help' for more "
 						"information.\n", progname);
 					return 1;

--- a/master.c
+++ b/master.c
@@ -130,7 +130,7 @@ init_pty(char **argv, int statusfd)
 		if (statusfd != -1)
 			dup2(statusfd, 1);
 		else
-			printf(EOS "\r\n");
+			printf("%s", clear_csi_data());
 
 		printf("%s: could not execute %s: %s\r\n", progname,
 		       *argv, strerror(errno));


### PR DESCRIPTION
I have made three (quite minor) changes, that are most helpful in scripted scenarios, where `dtach` is used behind the scenes.  Namely:

 * add support for `--` argument termination marker (just like other Linux tools), which allows one to have executables starting with `-`;  another side-effect of this patch is that in case `dtach` is used in a script where we can't trust the user input, now the user is not able to inject new options that are interpreted by `dtach`;  (for example it is used like `dtach -c socket -- ${@}`;

 * add support for `-q` option which, like other Linux tools makes `dtach` exit quietly if everything is OK;  basically it doesn't print anymore `[EOS ...]`;  in conjunction with the other patches which introduce the `-R` option, it makes `dtach` transparent when used in scripts;

 * add support for `-R` (the symmetric argument for `-r`), which allows the user how the terminal is cleared when the command exits or is detached;  the two options are `move` (the current behavior) and `none`, which just prints a new line;  the second variant allows one to use `dtach` in a loop for short commands, and still be able to read their output without having to scroll;  (one use-case is for example in a Jenkins job;)

If these patches are accepted I can also provide the necessary `man` updates.  (For now I have only added the embedded help documentation.)
