### PR TITLE
Add scrollback buffer for reattach context

### DIFF
--- a/attach.c
+++ b/attach.c
@@ -217,10 +217,9 @@ attach_main(int noerror)
 	cur_term.c_cc[VTIME] = 0;
 	tcsetattr(0, TCSADRAIN, &cur_term);
 
-	/* Clear the screen. This assumes VT100. */
-	write_buf_or_fail(1, "\33[H\33[J", 6);
-
-	/* Tell the master that we want to attach. */
+	/* Tell the master that we want to attach. The master will replay
+	** the scrollback buffer before marking us as attached, so we skip
+	** the old screen clear to preserve the replayed content. */
 	memset(&pkt, 0, sizeof(struct packet));
 	pkt.type = MSG_ATTACH;
 	write_packet_or_fail(s, &pkt);

--- a/dtach.1
+++ b/dtach.1
@@ -164,6 +164,25 @@ redraw method for the session. If not specified, the
 method is used.
 
 .TP
+.BI "\-b " "<size>"
+Sets the scrollback buffer size to
+.IR <size>
+bytes. When a new client attaches to a session, the contents of the
+scrollback buffer are replayed to the client, providing context of
+recent output. The
+.I <size>
+argument accepts optional
+.B K
+or
+.B M
+suffixes for kilobytes and megabytes respectively (e.g.
+.BR 256K ,
+.BR 1M ).
+Set to
+.B 0
+to disable the scrollback buffer. The default size is 256K.
+
+.TP
 .B \-z
 Disables processing of the suspend key.
 Normally,

--- a/dtach.h
+++ b/dtach.h
@@ -97,6 +97,7 @@ extern char *progname, *sockname;
 extern int detach_char, no_suspend, redraw_method;
 extern struct termios orig_term;
 extern int dont_have_tty;
+extern size_t scrollback_size;
 
 enum
 {
@@ -105,6 +106,7 @@ enum
 	MSG_DETACH	= 2,
 	MSG_WINCH	= 3,
 	MSG_REDRAW	= 4,
+	MSG_CONTENT	= 5,
 };
 
 enum
@@ -135,6 +137,9 @@ struct packet
 ** buffer used for the text stream.
 */
 #define BUFSIZE 4096
+
+/* Default scrollback buffer size (256KB). Set to 0 to disable. */
+#define DEFAULT_SCROLLBACK_SIZE (256 * 1024)
 
 /* This hopefully moves to the bottom of the screen */
 #define EOS "\033[999H"

--- a/main.c
+++ b/main.c
@@ -36,6 +36,8 @@ int detach_char = '\\' - 64;
 int no_suspend;
 /* The default redraw method. Initially set to unspecified. */
 int redraw_method = REDRAW_UNSPEC;
+/* The scrollback buffer size. */
+size_t scrollback_size = DEFAULT_SCROLLBACK_SIZE;
 
 /*
 ** The original terminal settings. Shared between the master and attach
@@ -120,6 +122,9 @@ usage()
 	       "\t\t     none: Don't redraw at all.\n"
 	       "\t\t   ctrl_l: Send a Ctrl L character to the program.\n"
 	       "\t\t    winch: Send a WINCH signal to the program.\n"
+	       "  -b <size>\tSet the scrollback buffer size in bytes.\n"
+	       "\t\t  Suffixes K and M are supported (e.g. 256K, 1M).\n"
+	       "\t\t  Set to 0 to disable. Default: 256K.\n"
 	       "  -z\t\tDisable processing of the suspend key.\n"
 	       "\nReport any bugs to <" PACKAGE_BUGREPORT ">.\n",
 		PACKAGE_VERSION, __DATE__, __TIME__);
@@ -254,6 +259,36 @@ main(int argc, char **argv)
 					       "information.\n", progname);
 					return 1;
 				}
+				break;
+			}
+			else if (*p == 'b')
+			{
+				char *end;
+				unsigned long val;
+
+				++argv; --argc;
+				if (argc < 1)
+				{
+					printf("%s: No scrollback size "
+					       "specified.\n", progname);
+					printf("Try '%s --help' for more "
+					       "information.\n", progname);
+					return 1;
+				}
+				val = strtoul(argv[0], &end, 10);
+				if (*end == 'k' || *end == 'K')
+					val *= 1024;
+				else if (*end == 'm' || *end == 'M')
+					val *= 1024 * 1024;
+				else if (*end != '\0')
+				{
+					printf("%s: Invalid scrollback size "
+					       "'%s'.\n", progname, argv[0]);
+					printf("Try '%s --help' for more "
+					       "information.\n", progname);
+					return 1;
+				}
+				scrollback_size = (size_t)val;
 				break;
 			}
 			else

--- a/master.c
+++ b/master.c
@@ -53,6 +53,75 @@ static struct client *clients;
 /* The pseudo-terminal created for the child process. */
 static struct pty the_pty;
 
+/* Circular scrollback buffer for replaying output to newly attached clients. */
+static struct {
+	unsigned char *data;
+	size_t size;    /* Total capacity */
+	size_t used;    /* Bytes currently stored (up to size) */
+	size_t head;    /* Write position (next byte goes here) */
+} scrollback;
+
+/* Initialize the scrollback buffer. */
+static void
+init_scrollback(void)
+{
+	if (scrollback_size == 0)
+		return;
+	scrollback.data = malloc(scrollback_size);
+	if (!scrollback.data)
+	{
+		scrollback.size = 0;
+		return;
+	}
+	scrollback.size = scrollback_size;
+	scrollback.used = 0;
+	scrollback.head = 0;
+}
+
+/* Append data to the scrollback buffer. */
+static void
+scrollback_push(const unsigned char *buf, size_t len)
+{
+	size_t i;
+
+	if (!scrollback.data || scrollback.size == 0)
+		return;
+
+	for (i = 0; i < len; i++)
+	{
+		scrollback.data[scrollback.head] = buf[i];
+		scrollback.head = (scrollback.head + 1) % scrollback.size;
+		if (scrollback.used < scrollback.size)
+			scrollback.used++;
+	}
+}
+
+/* Replay the scrollback buffer contents to a file descriptor. */
+static void
+scrollback_replay(int fd)
+{
+	size_t start, count;
+
+	if (!scrollback.data || scrollback.used == 0)
+		return;
+
+	if (scrollback.used < scrollback.size)
+	{
+		/* Buffer hasn't wrapped yet - data starts at 0 */
+		write_buf_or_fail(fd, scrollback.data, scrollback.used);
+	}
+	else
+	{
+		/* Buffer has wrapped - oldest data starts at head */
+		start = scrollback.head;
+		count = scrollback.size - start;
+		if (count > 0)
+			write_buf_or_fail(fd, scrollback.data + start, count);
+		if (start > 0)
+			write_buf_or_fail(fd, scrollback.data, start);
+	}
+}
+
 #ifndef HAVE_FORKPTY
 pid_t forkpty(int *amaster, char *name, struct termios *termp,
 	      struct winsize *winp);
@@ -272,6 +341,9 @@ pty_activity(int s)
 		exit(1);
 	}
 
+	/* Capture output into the scrollback buffer for later replay. */
+	scrollback_push(buf, len);
+
 #ifdef BROKEN_MASTER
 	/* Get the current terminal settings. */
 	if (tcgetattr(the_pty.slave, &the_pty.term) < 0)
@@ -398,7 +470,11 @@ client_activity(struct client *p)
 
 	/* Attach or detach from the program. */
 	else if (pkt.type == MSG_ATTACH)
+	{
+		/* Replay scrollback buffer so the client has context. */
+		scrollback_replay(p->fd);
 		p->attached = 1;
+	}
 	else if (pkt.type == MSG_DETACH)
 		p->attached = 0;
 
@@ -498,6 +574,9 @@ master_process(int s, char **argv, int waitattach, int statusfd)
 	dup2(nullfd, 2);
 	if (nullfd > 2)
 		close(nullfd);
+
+	/* Initialize the scrollback buffer for output replay. */
+	init_scrollback();
 
 	/* Loop forever. */
 	while (1)

--- a/master.c
+++ b/master.c
@@ -471,8 +471,17 @@ client_activity(struct client *p)
 	/* Attach or detach from the program. */
 	else if (pkt.type == MSG_ATTACH)
 	{
-		/* Replay scrollback buffer so the client has context. */
+		/* Replay scrollback buffer so the client has context.
+		** Wrap the replay in OSC delimiters so smart clients can
+		** distinguish replayed content from live PTY output.
+		** Unknown OSC sequences are silently ignored by terminals. */
+		static const char replay_start[] =
+			"\033]dtach-rev;replay-start\007";
+		static const char replay_end[] =
+			"\033]dtach-rev;replay-end\007";
+		write_buf_or_fail(p->fd, replay_start, sizeof(replay_start) - 1);
 		scrollback_replay(p->fd);
+		write_buf_or_fail(p->fd, replay_end, sizeof(replay_end) - 1);
 		p->attached = 1;
 	}
 	else if (pkt.type == MSG_DETACH)


### PR DESCRIPTION
Hey, I've been using dtach for a while and the one thing that always bugged me is losing all context when reattaching. This adds a simple circular buffer in the master that captures pty output and replays it when a new client attaches.

- Defaults to 256K, configurable with `-b <size>` (supports K/M suffixes, or 0 to disable)
- No impact on existing behavior if you pass `-b 0`
- Updated the man page

Happy to adjust anything if needed.