### PR TITLE
Add output history replay

### DIFF
--- a/dtach.1
+++ b/dtach.1
@@ -164,6 +164,13 @@ redraw method for the session. If not specified, the
 method is used.
 
 .TP
+.BI "\-H " "<bytes>"
+Sets the number of bytes of program output history retained in memory and
+replayed to newly attached clients. The default is 1048576 bytes. A value of
+0 disables history replay. The setting only affects newly created sessions;
+attaching to an existing session uses that session's configured history size.
+
+.TP
 .B \-z
 Disables processing of the suspend key.
 Normally,

--- a/dtach.h
+++ b/dtach.h
@@ -95,6 +95,7 @@
 
 extern char *progname, *sockname;
 extern int detach_char, no_suspend, redraw_method;
+extern size_t history_size;
 extern struct termios orig_term;
 extern int dont_have_tty;
 

--- a/main.c
+++ b/main.c
@@ -36,6 +36,8 @@ int detach_char = '\\' - 64;
 int no_suspend;
 /* The default redraw method. Initially set to unspecified. */
 int redraw_method = REDRAW_UNSPEC;
+/* Number of bytes of output history to replay when attaching. */
+size_t history_size = 1024 * 1024;
 
 /*
 ** The original terminal settings. Shared between the master and attach
@@ -120,6 +122,9 @@ usage()
 	       "\t\t     none: Don't redraw at all.\n"
 	       "\t\t   ctrl_l: Send a Ctrl L character to the program.\n"
 	       "\t\t    winch: Send a WINCH signal to the program.\n"
+	       "  -H <bytes>\tSet output history size in bytes, defaults "
+	       "to 1048576.\n"
+	       "\t\t  Use 0 to disable history replay.\n"
 	       "  -z\t\tDisable processing of the suspend key.\n"
 	       "\nReport any bugs to <" PACKAGE_BUGREPORT ">.\n",
 		PACKAGE_VERSION, __DATE__, __TIME__);
@@ -254,6 +259,35 @@ main(int argc, char **argv)
 					       "information.\n", progname);
 					return 1;
 				}
+				break;
+			}
+			else if (*p == 'H')
+			{
+				char *end;
+				unsigned long value;
+
+				++argv; --argc;
+				if (argc < 1)
+				{
+					printf("%s: No history size specified.\n",
+					       progname);
+					printf("Try '%s --help' for more information.\n",
+					       progname);
+					return 1;
+				}
+
+				errno = 0;
+				value = strtoul(argv[0], &end, 10);
+				if (argv[0][0] == '\0' || *end != '\0' || errno == ERANGE ||
+				    value > (unsigned long)((size_t)-1))
+				{
+					printf("%s: Invalid history size specified.\n",
+					       progname);
+					printf("Try '%s --help' for more information.\n",
+					       progname);
+					return 1;
+				}
+				history_size = (size_t)value;
 				break;
 			}
 			else

--- a/master.c
+++ b/master.c
@@ -53,6 +53,34 @@ static struct client *clients;
 /* The pseudo-terminal created for the child process. */
 static struct pty the_pty;
 
+struct history
+{
+	unsigned char *buf;
+	size_t cap;
+	size_t start;
+	size_t len;
+};
+
+enum history_filter_state
+{
+	HIST_FILTER_NORMAL,
+	HIST_FILTER_ESC,
+	HIST_FILTER_CSI,
+	HIST_FILTER_OSC,
+	HIST_FILTER_OSC_ESC
+};
+
+struct history_filter
+{
+	enum history_filter_state state;
+	unsigned char seq[4096];
+	size_t len;
+	int has_query;
+};
+
+static struct history output_history;
+static struct history_filter output_history_filter;
+
 #ifndef HAVE_FORKPTY
 pid_t forkpty(int *amaster, char *name, struct termios *termp,
 	      struct winsize *winp);
@@ -63,6 +91,222 @@ static void
 unlink_socket(void)
 {
 	unlink(sockname);
+}
+
+static void
+close_client(struct client *p)
+{
+	close(p->fd);
+	if (p->next)
+		p->next->pprev = p->pprev;
+	*(p->pprev) = p->next;
+	free(p);
+}
+
+static int
+init_history(void)
+{
+	memset(&output_history, 0, sizeof(output_history));
+	if (history_size == 0)
+		return 0;
+
+	output_history.buf = malloc(history_size);
+	if (!output_history.buf)
+		return -1;
+	output_history.cap = history_size;
+	return 0;
+}
+
+static void
+history_append_raw(const unsigned char *buf, size_t len)
+{
+	size_t end, first;
+
+	if (output_history.cap == 0 || len == 0)
+		return;
+
+	if (len >= output_history.cap)
+	{
+		memcpy(output_history.buf, buf + len - output_history.cap,
+		       output_history.cap);
+		output_history.start = 0;
+		output_history.len = output_history.cap;
+		return;
+	}
+
+	if (output_history.len + len > output_history.cap)
+	{
+		size_t drop = output_history.len + len - output_history.cap;
+
+		output_history.start = (output_history.start + drop) %
+		                       output_history.cap;
+		output_history.len -= drop;
+	}
+
+	end = (output_history.start + output_history.len) % output_history.cap;
+	first = output_history.cap - end;
+	if (first > len)
+		first = len;
+	memcpy(output_history.buf + end, buf, first);
+	if (len > first)
+		memcpy(output_history.buf, buf + first, len - first);
+	output_history.len += len;
+}
+
+static void
+history_filter_reset(void)
+{
+	output_history_filter.state = HIST_FILTER_NORMAL;
+	output_history_filter.len = 0;
+	output_history_filter.has_query = 0;
+}
+
+static void
+history_filter_buffer(unsigned char c)
+{
+	if (output_history_filter.len < sizeof(output_history_filter.seq))
+		output_history_filter.seq[output_history_filter.len++] = c;
+}
+
+static void
+history_filter_flush(void)
+{
+	history_append_raw(output_history_filter.seq, output_history_filter.len);
+	history_filter_reset();
+}
+
+static void
+history_filter_finish_osc(void)
+{
+	if (!output_history_filter.has_query)
+		history_append_raw(output_history_filter.seq,
+		                   output_history_filter.len);
+	history_filter_reset();
+}
+
+static void
+history_filter_finish_csi(unsigned char final)
+{
+	if (final != 'n')
+		history_append_raw(output_history_filter.seq,
+		                   output_history_filter.len);
+	history_filter_reset();
+}
+
+static void
+history_append(const unsigned char *buf, size_t len)
+{
+	size_t i;
+
+	if (output_history.cap == 0 || len == 0)
+		return;
+
+	for (i = 0; i < len; i++)
+	{
+		unsigned char c = buf[i];
+
+		switch (output_history_filter.state)
+		{
+		case HIST_FILTER_NORMAL:
+			if (c == '\033')
+			{
+				history_filter_reset();
+				history_filter_buffer(c);
+				output_history_filter.state = HIST_FILTER_ESC;
+			}
+			else
+				history_append_raw(&c, 1);
+			break;
+
+		case HIST_FILTER_ESC:
+			history_filter_buffer(c);
+			if (c == ']')
+				output_history_filter.state = HIST_FILTER_OSC;
+			else if (c == '[')
+				output_history_filter.state = HIST_FILTER_CSI;
+			else
+				history_filter_flush();
+			break;
+
+		case HIST_FILTER_CSI:
+			history_filter_buffer(c);
+			if (c >= 0x40 && c <= 0x7e)
+				history_filter_finish_csi(c);
+			break;
+
+		case HIST_FILTER_OSC:
+			history_filter_buffer(c);
+			if (c == '?')
+				output_history_filter.has_query = 1;
+			if (c == '\007')
+				history_filter_finish_osc();
+			else if (c == '\033')
+				output_history_filter.state = HIST_FILTER_OSC_ESC;
+			break;
+
+		case HIST_FILTER_OSC_ESC:
+			history_filter_buffer(c);
+			if (c == '\\')
+				history_filter_finish_osc();
+			else
+				output_history_filter.state = HIST_FILTER_OSC;
+			break;
+		}
+
+		if (output_history_filter.len == sizeof(output_history_filter.seq))
+			history_filter_flush();
+	}
+}
+
+static int
+write_client_buf(int fd, const unsigned char *buf, size_t len)
+{
+	while (len != 0)
+	{
+		ssize_t ret = write(fd, buf, len);
+
+		if (ret > 0)
+		{
+			buf += ret;
+			len -= ret;
+		}
+		else if (ret < 0 && errno == EINTR)
+			continue;
+		else if (ret < 0 && errno == EAGAIN)
+		{
+			fd_set writefds;
+
+			FD_ZERO(&writefds);
+			FD_SET(fd, &writefds);
+			if (select(fd + 1, NULL, &writefds, NULL, NULL) < 0 &&
+			    errno != EINTR)
+				return -1;
+		}
+		else
+			return -1;
+	}
+	return 0;
+}
+
+static int
+history_replay(int fd)
+{
+	size_t first;
+
+	if (output_history.len == 0)
+		return 0;
+
+	first = output_history.cap - output_history.start;
+	if (first > output_history.len)
+		first = output_history.len;
+	if (write_client_buf(fd, output_history.buf + output_history.start,
+	                     first) < 0)
+		return -1;
+	if (output_history.len > first &&
+	    write_client_buf(fd, output_history.buf,
+	                     output_history.len - first) < 0)
+		return -1;
+	return 0;
 }
 
 /* Signal */
@@ -272,6 +516,8 @@ pty_activity(int s)
 		exit(1);
 	}
 
+	history_append(buf, len);
+
 #ifdef BROKEN_MASTER
 	/* Get the current terminal settings. */
 	if (tcgetattr(the_pty.slave, &the_pty.term) < 0)
@@ -357,6 +603,11 @@ control_activity(int s)
 
 	/* Link it in. */
 	p = malloc(sizeof(struct client));
+	if (!p)
+	{
+		close(fd);
+		return;
+	}
 	p->fd = fd;
 	p->attached = 0;
 	p->pprev = &clients;
@@ -381,11 +632,7 @@ client_activity(struct client *p)
 	/* Close the client on an error. */
 	if (len != sizeof(struct packet))
 	{
-		close(p->fd);
-		if (p->next)
-			p->next->pprev = p->pprev;
-		*(p->pprev) = p->next;
-		free(p);
+		close_client(p);
 		return;
 	}
 
@@ -398,7 +645,11 @@ client_activity(struct client *p)
 
 	/* Attach or detach from the program. */
 	else if (pkt.type == MSG_ATTACH)
+	{
 		p->attached = 1;
+		if (history_replay(p->fd) < 0)
+			close_client(p);
+	}
 	else if (pkt.type == MSG_DETACH)
 		p->attached = 0;
 
@@ -576,6 +827,12 @@ master_main(char **argv, int waitattach, int dontfork)
 	/* Use a default redraw method if one hasn't been specified yet. */
 	if (redraw_method == REDRAW_UNSPEC)
 		redraw_method = REDRAW_CTRL_L;
+
+	if (init_history() < 0)
+	{
+		printf("%s: history buffer: %s\n", progname, strerror(errno));
+		return 1;
+	}
 
 	/* Create the unix domain socket. */
 	s = create_socket(sockname);

--- a/tests/history_filter.py
+++ b/tests/history_filter.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+import os
+import pty
+import select
+import signal
+import subprocess
+import tempfile
+import time
+
+
+OSC_BG_QUERY = b"\x1b]11;?\x1b\\"
+CSI_CURSOR_QUERY = b"\x1b[6n"
+
+
+def read_available(fd, timeout=1.0):
+    deadline = time.time() + timeout
+    chunks = []
+    while time.time() < deadline:
+        ready, _, _ = select.select([fd], [], [], 0.05)
+        if not ready:
+            continue
+        try:
+            chunk = os.read(fd, 4096)
+        except OSError:
+            break
+        if not chunk:
+            break
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+def main():
+    repo = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    dtach = os.environ.get("DTACH", os.path.join(repo, "dtach"))
+    with tempfile.TemporaryDirectory() as tmp:
+        sock = os.path.join(tmp, "hist.sock")
+        command = "printf 'before\\n\033]11;?\033\\\\middle\\n\033[6nafter\\n'; sleep 10"
+        subprocess.check_call([dtach, "-n", sock, "/bin/sh", "-c", command])
+        time.sleep(0.2)
+
+        master, slave = pty.openpty()
+        proc = subprocess.Popen([dtach, "-a", sock], stdin=slave, stdout=slave, stderr=slave)
+        os.close(slave)
+        try:
+            output = read_available(master, timeout=1.0)
+        finally:
+            proc.send_signal(signal.SIGTERM)
+            try:
+                proc.wait(timeout=1)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=1)
+            os.close(master)
+
+        assert b"before" in output, output
+        assert b"middle" in output, output
+        assert b"after" in output, output
+        assert OSC_BG_QUERY not in output, output
+        assert CSI_CURSOR_QUERY not in output, output
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add an in-memory ring buffer for recent program output in the master process.
- Replay retained output history when a new client attaches.
- Add `-H <bytes>` to configure history size, with `-H 0` disabling replay.
- Document the new option in the man page and help output.

## Test Plan
- `make -C /Users/bytedance/Github/dtach`
- Verified default history replay by starting an unattached session that prints output, then attaching and checking the output is replayed.
- Verified `-H 0` disables history replay.
- Verified small history buffers keep only the newest bytes.
- Verified invalid `-H` values are rejected.